### PR TITLE
[Sikkerhet] Oppdaterer med catalog-info.yaml til versjon 3.0

### DIFF
--- a/.sikkerhet/beskrivelse.yaml
+++ b/.sikkerhet/beskrivelse.yaml
@@ -1,4 +1,4 @@
-version: 2.0
+version: 3.0
 organization: IT
 product: 
 repo_types: [Tool]

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,37 @@
+# nonk8s
+apiVersion: "backstage.io/v1alpha1"
+kind: "Component"
+metadata:
+  name: "UML-dokumentasjon-AsciiDoc-Script"
+  tags:
+  - "private"
+spec:
+  type: "service"
+  lifecycle: "production"
+  owner: "standardisering"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Group"
+metadata:
+  name: "security_champion_UML-dokumentasjon-AsciiDoc-Script"
+  title: "Security Champion UML-dokumentasjon-AsciiDoc-Script"
+spec:
+  type: "security_champion"
+  parent: "it_security_champions"
+  members:
+  - "toreJohnsen"
+  children:
+  - "resource:UML-dokumentasjon-AsciiDoc-Script"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Resource"
+metadata:
+  name: "UML-dokumentasjon-AsciiDoc-Script"
+  links:
+  - url: "https://github.com/kartverket/UML-dokumentasjon-AsciiDoc-Script"
+    title: "UML-dokumentasjon-AsciiDoc-Script på GitHub"
+spec:
+  type: "repo"
+  owner: "security_champion_UML-dokumentasjon-AsciiDoc-Script"
+  dependencyOf:
+  - "component:UML-dokumentasjon-AsciiDoc-Script"


### PR DESCRIPTION
Denne PRen oppdaterer `catalog-info.yaml` for å gi entiteter til Backstage, samtidig som `beskrivelse.yaml` nå går til `version: 3.0`.
Det er beskrevet [her i Sikkerhetshåndboka](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732397586/Sikkerhet+i+repoet) hvorfor vi gjør dette.